### PR TITLE
osc breaks with workspace errors using symlinks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ members = [
 	"src/nss",
 	"src/glue",
 	"src/policies",
-	"src/sketching",
+	"src/kanidm/libs/sketching",
 	"src/proto",
-	"src/crypto",
+	"src/kanidm/libs/crypto",
 ]
 
 [workspace.package]
@@ -63,9 +63,9 @@ openssl-sys = "^0.9"
 openssl = "^0.10.55"
 rand = "^0.8.5"
 tss-esapi = "^7.2.0"
-sketching = { path = "./src/sketching" }
+sketching = { path = "./src/kanidm/libs/sketching" }
 tracing-forest = "^0.1.6"
 rusqlite = "^0.28.0"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 lru = "^0.8.0"
-kanidm_lib_crypto = { path = "./src/crypto", version = "0.1.0" }
+kanidm_lib_crypto = { path = "./src/kanidm/libs/crypto", version = "0.1.0" }

--- a/src/crypto
+++ b/src/crypto
@@ -1,1 +1,0 @@
-kanidm/libs/crypto

--- a/src/sketching
+++ b/src/sketching
@@ -1,1 +1,0 @@
-kanidm/libs/sketching


### PR DESCRIPTION
osc was picking up the kanidm Cargo.toml without
symlinks, but with them the workspace is broken.
Instead switching to no symlinks and excluding
the kanidm Cargo.toml from the build tar.